### PR TITLE
Fix: git HEAD is case-sensitive on Linux

### DIFF
--- a/src/git_info.py
+++ b/src/git_info.py
@@ -12,7 +12,7 @@ def run():
     # revision is simply the count of revs in the current branch
     # this won't be perfect in all cases, but there's no possible way to produce a perfect single rev with git
     # so this is good enough
-    revision = exe_cmd(['git', 'rev-list', '--count', 'head'])
+    revision = exe_cmd(['git', 'rev-list', '--count', 'HEAD'])
     # for the version we just use git describe, which gives us a recent tag or so
     version = exe_cmd(['git', 'describe'])
 


### PR DESCRIPTION
> fatal: ambiguous argument 'head':
>  unknown revision or path not in the working tree.