### PR TITLE
Add: Wood Chips recolour and vehicle categorization

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -114,6 +114,7 @@ cargo_labels = [
     "STSE",
     "SEED",
     "TATO",
+    "WDCH",
     #
     "NULL",
 ]
@@ -303,7 +304,7 @@ default_cargos = {
     "cryo_gases": ["O2__", "CHLO"],
     "dump": ["MNO2", "FECR", "NITR", "PHOS", "SAND", "GRVL"],
     "dump_aggregates": ["LIME", "GRVL", "SAND", "CLAY"],
-    "dump_high_sides": ["COKE", "PEAT", "COAL"],
+    "dump_high_sides": ["COKE", "PEAT", "COAL", "WDCH"],
     "dump_ore": ["IORE", "PHOS", "PORE", "CORE"],
     "dump_scrap": ["SCMT", "COAL"],
     "edibles_tank": ["WATR", "MILK", "BEER"],
@@ -613,6 +614,7 @@ bulk_cargo_recolour_maps_extended = (
     ("SGBT", "1CC", {170: 60, 171: 53, 172: 54, 173: 55, 174: 56, 175: 57, 176: 58}),
     ("SLAG", "1CC", {170: 24, 171: 3, 172: 2, 173: 3, 174: 4, 175: 5, 176: 5}),
     ("SULP", "1CC", {170: 65, 171: 67, 172: 66, 173: 67, 174: 68, 175: 69, 176: 69}),
+    ("WDCH", "2CC", {170: 108, 171: 64, 172: 65, 173: 197, 174: 36, 175: 196, 176: 197}),
 )
 
 bulk_cargo_recolour_maps = [(i[0], i[2]) for i in bulk_cargo_recolour_maps_extended]


### PR DESCRIPTION
Adds support for Wood Chips in [Improved Town Industries 2](https://github.com/2TallTyler/improved_town_industries) and Lumberjack Industries 2 (not yet released).