### PR TITLE
Add: "BAKE" (Flour/Starch) to covered hoppers refit list

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -114,6 +114,7 @@ cargo_labels = [
     "STSE",
     "SEED",
     "TATO",
+    "BAKE",
     #
     "NULL",
 ]
@@ -183,6 +184,7 @@ allowed_refits_by_label = {
         "SALT",
         "PLAS",
         "PHOS",
+        "BAKE",
     ],  # not CBLK, gets dedicated vehicles or box
     "cryo_gases": ["CHLO", "O2__", "NH3_"],
     "edible_liquids": ["MILK", "WATR", "BEER", "FOOD", "EOIL"],


### PR DESCRIPTION
Per our Discord discussion.

"BAKE" is used for Flour by OTIS and for Starch by Lumberjack Industries 2. 
